### PR TITLE
WrenSec Builds - Phase #1 (for wrensec-guava)

### DIFF
--- a/.wren-deploy.rc
+++ b/.wren-deploy.rc
@@ -1,0 +1,14 @@
+export MAVEN_PACKAGE="forgerock-guava"
+export BINTRAY_PACKAGE="wrensec-guava"
+export JFROG_PACKAGE="org/forgerock/guava"
+
+package_accept_release_tag() {
+  local tag_name="${1}"
+
+  if [[ "${tag_name}" != "18.0.3" && "${tag_name}" != "18.0.4" ]]; then
+    echo "Skipping ${tag_name} since we only want to build 18.0.3 and 18.0.4 right now."
+    return -1
+  else
+    return 0
+  fi
+}

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2014-2015 ForgeRock AS.
+  Copyright 2017 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -23,8 +24,8 @@
     </parent>
     <packaging>jar</packaging>
     <artifactId>forgerock-guava-all</artifactId>
-    <name>Google Guava</name>
-    <description>Repackaged version of Guava to avoid dependency collisions.</description>
+    <name>Wren Security Guava - Full Google Guava Package</name>
+    <description>Provides the entire Google Guava package. Other packages repackage the contents of this package to avoid dependency collisions.</description>
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2014-2015 ForgeRock AS.
+  Copyright 2017 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -23,8 +24,8 @@
     </parent>
     <packaging>jar</packaging>
     <artifactId>forgerock-guava-annotations</artifactId>
-    <name>Google Guava Annotations</name>
-    <description>Repackaged version of Guava to avoid dependency collisions.</description>
+    <name>Wren Security Guava - Annotations</name>
+    <description>Provides common annotation types. Repackaged to avoid dependency collisions.</description>
     <dependencies>
         <dependency>
             <groupId>org.forgerock.commons.guava</groupId>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2014-2015 ForgeRock AS.
+  Copyright 2017 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -23,8 +24,8 @@
     </parent>
     <packaging>jar</packaging>
     <artifactId>forgerock-guava-base</artifactId>
-    <name>Google Guava Base</name>
-    <description>Repackaged version of Guava to avoid dependency collisions.</description>
+    <name>Wren Security Guava - Base</name>
+    <description>Provides basic utility libraries and interfaces. Repackaged to avoid dependency collisions.</description>
     <dependencies>
         <dependency>
             <groupId>org.forgerock.commons.guava</groupId>

--- a/cache/pom.xml
+++ b/cache/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2014-2015 ForgeRock AS.
+  Copyright 2017 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -23,8 +24,8 @@
     </parent>
     <packaging>jar</packaging>
     <artifactId>forgerock-guava-cache</artifactId>
-    <name>Google Guava Cache</name>
-    <description>Repackaged version of Guava to avoid dependency collisions.</description>
+    <name>Wren Security Guava - Cache</name>
+    <description>Provides utilities for in-memory and loadable caching. Repackaged to avoid dependency collisions.</description>
     <dependencies>
         <dependency>
             <groupId>org.forgerock.commons.guava</groupId>

--- a/collect/pom.xml
+++ b/collect/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2014-2015 ForgeRock AS.
+  Copyright 2017 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -23,8 +24,8 @@
     </parent>
     <packaging>jar</packaging>
     <artifactId>forgerock-guava-collect</artifactId>
-    <name>Google Guava Collections</name>
-    <description>Repackaged version of Guava to avoid dependency collisions.</description>
+    <name>Wren Security Guava - Collections</name>
+    <description>Provides generic collection interfaces and implementations, and other utilities for working with collections. Repackaged to avoid dependency collisions.</description>
     <dependencies>
         <dependency>
             <groupId>org.forgerock.commons.guava</groupId>

--- a/concurrent/pom.xml
+++ b/concurrent/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2014-2015 ForgeRock AS.
+  Copyright 2017 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -23,8 +24,8 @@
     </parent>
     <packaging>jar</packaging>
     <artifactId>forgerock-guava-concurrent</artifactId>
-    <name>Google Guava Concurrent</name>
-    <description>Repackaged version of Guava to avoid dependency collisions.</description>
+    <name>Wren Security Guava - Concurrency</name>
+    <description>Provides utilities for working with concurrency, including threads, Executors, and Futures. Repackaged to avoid dependency collisions.</description>
     <dependencies>
         <dependency>
             <groupId>org.forgerock.commons.guava</groupId>

--- a/escape/pom.xml
+++ b/escape/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2014-2015 ForgeRock AS.
+  Copyright 2017 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -23,8 +24,8 @@
     </parent>
     <packaging>jar</packaging>
     <artifactId>forgerock-guava-escape</artifactId>
-    <name>Google Guava Escape</name>
-    <description>Repackaged version of Guava to avoid dependency collisions.</description>
+    <name>Wren Security Guava - Escape</name>
+    <description>Provides interfaces, utilities, and simple implementations of escapers and encoders. Repackaged to avoid dependency collisions.</description>
     <dependencies>
         <dependency>
             <groupId>org.forgerock.commons.guava</groupId>

--- a/eventbus/pom.xml
+++ b/eventbus/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2014-2015 ForgeRock AS.
+  Portions Copyright 2017 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -23,8 +24,8 @@
     </parent>
     <packaging>jar</packaging>
     <artifactId>forgerock-guava-eventbus</artifactId>
-    <name>Google Guava Event Bus</name>
-    <description>Repackaged version of Guava to avoid dependency collisions.</description>
+    <name>Wren Security Guava - Event Bus</name>
+    <description>Allows publish-subscribe-style communication between components without requiring the components to explicitly register with one another Repackaged to avoid dependency collisions.</description>
     <dependencies>
         <dependency>
             <groupId>org.forgerock.commons.guava</groupId>

--- a/hash/pom.xml
+++ b/hash/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2014-2015 ForgeRock AS.
+  Portions Copyright 2017 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -23,8 +24,8 @@
     </parent>
     <packaging>jar</packaging>
     <artifactId>forgerock-guava-hash</artifactId>
-    <name>Google Guava Hash</name>
-    <description>Repackaged version of Guava to avoid dependency collisions.</description>
+    <name>Wren Security Guava - Hash</name>
+    <description>Provides hash functions and related structures. Repackaged to avoid dependency collisions.</description>
     <dependencies>
         <dependency>
             <groupId>org.forgerock.commons.guava</groupId>

--- a/html/pom.xml
+++ b/html/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2014-2015 ForgeRock AS.
+  Portions Copyright 2017 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -23,8 +24,8 @@
     </parent>
     <packaging>jar</packaging>
     <artifactId>forgerock-guava-html</artifactId>
-    <name>Google Guava HTML</name>
-    <description>Repackaged version of Guava to avoid dependency collisions.</description>
+    <name>Wren Security Guava - HTML</name>
+    <description>Escapers for HTML. Repackaged to avoid dependency collisions.</description>
     <dependencies>
         <dependency>
             <groupId>org.forgerock.commons.guava</groupId>

--- a/io/pom.xml
+++ b/io/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2014-2015 ForgeRock AS.
+  Portions Copyright 2017 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -23,8 +24,8 @@
     </parent>
     <packaging>jar</packaging>
     <artifactId>forgerock-guava-io</artifactId>
-    <name>Google Guava IO</name>
-    <description>Repackaged version of Guava to avoid dependency collisions.</description>
+    <name>Wren Security Guava - IO</name>
+    <description>Provides utility methods and classes for working with Java I/O; for example input streams, output streams, readers, writers, and files. Repackaged to avoid dependency collisions.</description>
     <dependencies>
         <dependency>
             <groupId>org.forgerock.commons.guava</groupId>

--- a/math/pom.xml
+++ b/math/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2014-2015 ForgeRock AS.
+  Portions Copyright 2017 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -23,8 +24,8 @@
     </parent>
     <packaging>jar</packaging>
     <artifactId>forgerock-guava-math</artifactId>
-    <name>Google Guava Math</name>
-    <description>Repackaged version of Guava to avoid dependency collisions.</description>
+    <name>Wren Security Guava - Math</name>
+    <description>Provides arithmetic functions operating on primitive values and BigInteger instances. Repackaged to avoid dependency collisions.</description>
     <dependencies>
         <dependency>
             <groupId>org.forgerock.commons.guava</groupId>

--- a/net/pom.xml
+++ b/net/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2014-2015 ForgeRock AS.
+  Portions Copyright 2017 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -23,8 +24,8 @@
     </parent>
     <packaging>jar</packaging>
     <artifactId>forgerock-guava-net</artifactId>
-    <name>Google Guava Net</name>
-    <description>Repackaged version of Guava to avoid dependency collisions.</description>
+    <name>Wren Security Guava - Net</name>
+    <description>Provides utility methods and classes for working with net addresses (numeric IP and domain names). Repackaged to avoid dependency collisions.</description>
     <dependencies>
         <dependency>
             <groupId>org.forgerock.commons.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
  
   Copyright 2014-2015 ForgeRock AS.
+  Portions Copyright 2017 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -25,7 +26,7 @@
     <groupId>org.forgerock.commons.guava</groupId>
     <artifactId>forgerock-guava</artifactId>
     <version>18.0.4</version>
-    <name>ForgeRock Guava</name>
+    <name>Wren Security Guava - Parent</name>
     <description>Repackaged version of Guava to avoid dependency collisions.</description>
     <modules>
         <module>all</module>
@@ -184,20 +185,24 @@
     </build>
     <!-- Maven Repositories -->
     <repositories>
-        <!-- ForgeRock Common Internal Project Repositories -->
+        <!-- Needed to retrieve parent POM -->
         <repository>
-            <id>forgerock-staging-repo</id>
-            <name>ForgeRock Release Repository</name>
-            <url>http://maven.forgerock.org/repo/releases</url>
+            <id>wrensecurity-releases</id>
+            <name>Wren Security Release Repository</name>
+            <url>https://wrensecurity.jfrog.io/wrensecurity/releases</url>
+
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
+
+            <releases>
+                <enabled>true</enabled>
+            </releases>
         </repository>
     </repositories>
     <scm>
-        <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-guava.git</connection>
-        <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-guava.git</developerConnection>
-        <url>http://stash.forgerock.org/projects/COMMONS/repos/forgerock-guava/browse</url>
-      <tag>18.0.4</tag>
-  </scm>
+        <url>https://github.com/WrenSecurity/wrensec-guava</url>
+        <connection>scm:git:git://github.com/WrenSecurity/wrensec-guava.git</connection>
+        <developerConnection>scm:git:git@github.com:WrenSecurity/wrensec-guava.git</developerConnection>
+    </scm>
  </project>

--- a/primitives/pom.xml
+++ b/primitives/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2014-2015 ForgeRock AS.
+  Portions Copyright 2017 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -23,8 +24,8 @@
     </parent>
     <packaging>jar</packaging>
     <artifactId>forgerock-guava-primitives</artifactId>
-    <name>Google Guava Primitives</name>
-    <description>Repackaged version of Guava to avoid dependency collisions.</description>
+    <name>Wren Security Guava - Primitives</name>
+    <description>Provides static utilities for working with the eight primitive types and "void", and value types for treating them as unsigned. Repackaged to avoid dependency collisions.</description>
     <dependencies>
         <dependency>
             <groupId>org.forgerock.commons.guava</groupId>

--- a/reflect/pom.xml
+++ b/reflect/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2014-2015 ForgeRock AS.
+  Portions Copyright 2017 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -23,8 +24,8 @@
     </parent>
     <packaging>jar</packaging>
     <artifactId>forgerock-guava-reflect</artifactId>
-    <name>Google Guava Reflection</name>
-    <description>Repackaged version of Guava to avoid dependency collisions.</description>
+    <name>Wren Security Guava - Reflection</name>
+    <description>Provides utilities to work with Java reflection. Repackaged to avoid dependency collisions.</description>
     <dependencies>
         <dependency>
             <groupId>org.forgerock.commons.guava</groupId>

--- a/xml/pom.xml
+++ b/xml/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2014-2015 ForgeRock AS.
+  Portions Copyright 2017 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -23,8 +24,8 @@
     </parent>
     <packaging>jar</packaging>
     <artifactId>forgerock-guava-xml</artifactId>
-    <name>Google Guava XML</name>
-    <description>Repackaged version of Guava to avoid dependency collisions.</description>
+    <name>Wren Security Guava - XML</name>
+    <description>Escapers for XML. Repackaged to avoid dependency collisions.</description>
     <dependencies>
         <dependency>
             <groupId>org.forgerock.commons.guava</groupId>


### PR DESCRIPTION
- modifies the POMs to build using Wren's repos.
- updates branding to call this Wren Security Guava instead of ForgeRock Guava / Google Guava.
- added more useful package descriptions.
- adds [Wren Deploy](https://github.com/WrenSecurity/wrensec-deploy-tool) RC file.
- the `sustaining/*` branches have already been updated with similar changes.